### PR TITLE
brackets replaced to parenthesis in result filename, version 3.2.0

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -102,6 +102,8 @@ ts-node options location | false | | Location of the ts-node options. If you lea
 
 ## <a id="release-notes"></a>Release Notes
 
+* 3.2.0 (22/09/2017)
+    * Support `[]` brackets in the display name of the task.
 * 3.1.0 (21/09/2017)
     * Support for TypeScript webpack configuration is added.
     * The ts-node module location can be modified.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ ts-node options location | false | | Location of the ts-node options. If you lea
 
 ## <a id="release-notes"></a>Release Notes
 
+* 3.2.0 (22/09/2017)
+    * Support `[]` brackets in the display name of the task.
 * 3.1.0 (21/09/2017)
     * Support for TypeScript webpack configuration is added.
     * The ts-node module location can be modified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wepback-vsts-extension",
-  "version": "3.0.19",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wepback-vsts-extension",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "webpack Visual Studio Team System (VSTS) Extension",
   "main": "index.js",
   "scripts": {

--- a/samples/webpack-2/package-lock.json
+++ b/samples/webpack-2/package-lock.json
@@ -1524,15 +1524,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1542,6 +1533,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/samples/webpack-3-with-issues/package-lock.json
+++ b/samples/webpack-3-with-issues/package-lock.json
@@ -2539,15 +2539,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2557,6 +2548,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/samples/webpack-3/package-lock.json
+++ b/samples/webpack-3/package-lock.json
@@ -2539,15 +2539,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2557,6 +2548,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/samples/webpack-ts-config/package-lock.json
+++ b/samples/webpack-ts-config/package-lock.json
@@ -2748,15 +2748,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2788,6 +2779,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/tasks/webpack-build-task/package-lock.json
+++ b/tasks/webpack-build-task/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-build-task",
-  "version": "3.0.19",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tasks/webpack-build-task/package.json
+++ b/tasks/webpack-build-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-build-task",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Webpack build task for Visual Studio Team System (VSTS)",
   "main": "index.js",
   "scripts": {},

--- a/tasks/webpack-build-task/summarySectionBuilder/index.ts
+++ b/tasks/webpack-build-task/summarySectionBuilder/index.ts
@@ -6,7 +6,8 @@ import { IWebpackCompilationResult } from "../webpackCompiler";
 const generateWebpackResultFilename = (workingFolder: string, taskDisplayName: string) => {
     const webpackResultFilenamePostfix = ".webpack.result.md";
 
-    return path.join(workingFolder, `${filenamify(taskDisplayName).trim()}${webpackResultFilenamePostfix}`);
+    const filename = filenamify(taskDisplayName).replace(/\[/g, "(").replace(/\]/g, ")").trim();
+    return path.join(workingFolder, `${filename}${webpackResultFilenamePostfix}`);
 };
 
 const createWebpackResultMarkdownFile = (

--- a/tasks/webpack-build-task/task.json
+++ b/tasks/webpack-build-task/task.json
@@ -16,7 +16,7 @@
     ],
     "version": {
         "Major": 3,
-        "Minor": 1,
+        "Minor": 2,
         "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",

--- a/tasks/webpack-build-task/tests/mockRunnerDefinitions/shouldReplaceBracketsToParenthesisInFilename.ts
+++ b/tasks/webpack-build-task/tests/mockRunnerDefinitions/shouldReplaceBracketsToParenthesisInFilename.ts
@@ -1,0 +1,17 @@
+import runTestTask from "./shared/testTaskRunner";
+
+runTestTask({
+    webpackCompilationResult: {
+        toJson: () => {
+            return {
+                errors: [],
+                warnings: []
+            };
+        },
+        toString: (config: any) => {
+            return "shouldReplaceBracketsToParenthesisInFilename";
+        }
+    },
+    taskDisplayName: "webpack [something in brackets]",
+    mockWriteFile: true
+});

--- a/tasks/webpack-build-task/tests/shouldReplaceBracketsToParenthesisInFilename.ts
+++ b/tasks/webpack-build-task/tests/shouldReplaceBracketsToParenthesisInFilename.ts
@@ -1,0 +1,22 @@
+import * as path from "path";
+import { MockTestRunner } from "vsts-task-lib/mock-test";
+import { assert } from "chai";
+
+const mockRunnerDefinitions = "mockRunnerDefinitions";
+
+export const executeTest = (done: MochaDone) => {
+        const testPath = path.join(__dirname, mockRunnerDefinitions, "shouldReplaceBracketsToParenthesisInFilename.js");
+        const testRunner = new MockTestRunner(testPath);
+        testRunner.run();
+
+        assert.isTrue(testRunner.succeeded, "task should be succeeded");
+        assert.isFalse(testRunner.failed, "task should be not failed");
+
+        const resultFileIsAttached = testRunner.stdOutContained("##vso[task.addattachment type=Distributedtask.Core.Summary;name=webpack [something in brackets] result;]");
+        assert.isTrue(resultFileIsAttached, "result file should be attached");
+
+        const resultFilenameConverted = testRunner.stdOutContained("webpack (something in brackets).webpack.result.md");
+        assert.isTrue(resultFilenameConverted, "attached filename should contain normal parenthesis");
+
+        done();
+};

--- a/tasks/webpack-build-task/tests/suite.ts
+++ b/tasks/webpack-build-task/tests/suite.ts
@@ -11,6 +11,7 @@ import * as shouldGenerateMarkdownFileInCaseOfASuccessfulRun from "./shouldGener
 import * as shouldLogInformationAboutTheProcess from "./shouldLogInformationAboutTheProcess";
 import * as shouldPartiallySucceedIfNoErrorsButAtLeastOneWarning from "./shouldPartiallySucceedIfNoErrorsButAtLeastOneWarning";
 import * as shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning from "./shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning";
+import * as shouldReplaceBracketsToParenthesisInFilename from "./shouldReplaceBracketsToParenthesisInFilename";
 import * as shouldReportErrorDetailInCaseOfWebpackBuildFailure from "./shouldReportErrorDetailInCaseOfWebpackBuildFailure";
 import * as shouldSucceedIfNoDisplayNameDefined from "./shouldSucceedIfNoDisplayNameDefined";
 import * as shouldSucceedIfNoErrorsAndWarnings from "./shouldSucceedIfNoErrorsAndWarnings";
@@ -26,7 +27,8 @@ describe("webpack build task", () => {
             "../../samples/webpack-3/webpack test.webpack.result.md",
             "../../samples/webpack-3-with-issues/webpack test.webpack.result.md",
             "../../samples/webpack-ts-config/webpack test.webpack.result.md",
-            "tests/webpack test.webpack.result.md"
+            "tests/webpack test.webpack.result.md",
+            "tests/webpack (something in brackets).webpack.result.md"
         ];
 
         for (const fileToDelete of filesToDelete) {
@@ -91,6 +93,11 @@ describe("webpack build task", () => {
     it(
         "should partially succeed if there are errors, but those are treated as warnings",
         shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning.executeTest);
+
+    it(
+        "should replace brackets to parenthesis in filename",
+        shouldReplaceBracketsToParenthesisInFilename.executeTest
+    );
 
     it(
         "should report error detail in case of webpack build failure",

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export default "__GitVersion.SemVer__".replace("GitVersion.SemVer", "3.1.0").replace(/__/g, "");
+export default "__GitVersion.SemVer__".replace("GitVersion.SemVer", "3.2.0").replace(/__/g, "");

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "webpack-vsts-extension",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "name": "webpack",
     "description": "bundle your assets, scripts, images, styles",
     "publisher": "Dealogic",


### PR DESCRIPTION
Provide an enhancement for issue #54 Webpack summary file error. In that issue turned out `[]` brackets are not supported in filename to attach into VSTS.