### PR TITLE
Bug/brackets replacement

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -102,6 +102,8 @@ ts-node options location | false | | Location of the ts-node options. If you lea
 
 ## <a id="release-notes"></a>Release Notes
 
+* 3.2.1 (22(09/2017)
+    * Replacing `[]` brackets to `()` parenthesis in the title of the result summary section.
 * 3.2.0 (22/09/2017)
     * Support `[]` brackets in the display name of the task.
 * 3.1.0 (21/09/2017)

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,2 @@
-next-version: 3.2.0
+next-version: 3.2.1
 assembly-informational-format: '{SemVer}'

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ ts-node options location | false | | Location of the ts-node options. If you lea
 
 ## <a id="release-notes"></a>Release Notes
 
+* 3.2.1 (22(09/2017)
+    * Replacing `[]` brackets to `()` parenthesis in the title of the result summary section.
 * 3.2.0 (22/09/2017)
     * Support `[]` brackets in the display name of the task.
 * 3.1.0 (21/09/2017)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wepback-vsts-extension",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wepback-vsts-extension",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "webpack Visual Studio Team System (VSTS) Extension",
   "main": "index.js",
   "scripts": {

--- a/tasks/webpack-build-task/package-lock.json
+++ b/tasks/webpack-build-task/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-build-task",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tasks/webpack-build-task/package.json
+++ b/tasks/webpack-build-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-build-task",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Webpack build task for Visual Studio Team System (VSTS)",
   "main": "index.js",
   "scripts": {},

--- a/tasks/webpack-build-task/summarySectionBuilder/index.ts
+++ b/tasks/webpack-build-task/summarySectionBuilder/index.ts
@@ -6,8 +6,7 @@ import { IWebpackCompilationResult } from "../webpackCompiler";
 const generateWebpackResultFilename = (workingFolder: string, taskDisplayName: string) => {
     const webpackResultFilenamePostfix = ".webpack.result.md";
 
-    const filename = filenamify(taskDisplayName).replace(/\[/g, "(").replace(/\]/g, ")").trim();
-    return path.join(workingFolder, `${filename}${webpackResultFilenamePostfix}`);
+    return path.join(workingFolder, `${filenamify(taskDisplayName).trim()}${webpackResultFilenamePostfix}`);
 };
 
 const createWebpackResultMarkdownFile = (
@@ -18,13 +17,15 @@ const createWebpackResultMarkdownFile = (
 
     console.log("webpack summary section markdown file creation is started");
 
-    const webpackResultFilename = generateWebpackResultFilename(workingFolder, taskDisplayName);
+    const fixedTaskDisplayName = taskDisplayName.replace(/\[/g, "(").replace(/\]/g, ")").trim();
+
+    const webpackResultFilename = generateWebpackResultFilename(workingFolder, fixedTaskDisplayName);
     const resultFileContent = `<pre>${result.toString(webpackConfiguration)}</pre>`;
 
     tl.writeFile(webpackResultFilename, resultFileContent);
 
     console.log(`webpack sumamry section markdown file is created with the name '${webpackResultFilename}'`);
-    console.log(`##vso[task.addattachment type=Distributedtask.Core.Summary;name=${taskDisplayName} result;]${webpackResultFilename}`);
+    console.log(`##vso[task.addattachment type=Distributedtask.Core.Summary;name=${fixedTaskDisplayName} result;]${webpackResultFilename}`);
 };
 
 export {

--- a/tasks/webpack-build-task/task.json
+++ b/tasks/webpack-build-task/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 3,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/tasks/webpack-build-task/tests/mockRunnerDefinitions/shouldReplaceBracketsToParenthesisInTaskName.ts
+++ b/tasks/webpack-build-task/tests/mockRunnerDefinitions/shouldReplaceBracketsToParenthesisInTaskName.ts
@@ -9,7 +9,7 @@ runTestTask({
             };
         },
         toString: (config: any) => {
-            return "shouldReplaceBracketsToParenthesisInFilename";
+            return "shouldReplaceBracketsToParenthesisInTaskName";
         }
     },
     taskDisplayName: "webpack [something in brackets]",

--- a/tasks/webpack-build-task/tests/shouldReplaceBracketsToParenthesisInFilename.ts
+++ b/tasks/webpack-build-task/tests/shouldReplaceBracketsToParenthesisInFilename.ts
@@ -12,7 +12,7 @@ export const executeTest = (done: MochaDone) => {
         assert.isTrue(testRunner.succeeded, "task should be succeeded");
         assert.isFalse(testRunner.failed, "task should be not failed");
 
-        const resultFileIsAttached = testRunner.stdOutContained("##vso[task.addattachment type=Distributedtask.Core.Summary;name=webpack [something in brackets] result;]");
+        const resultFileIsAttached = testRunner.stdOutContained("##vso[task.addattachment type=Distributedtask.Core.Summary;name=webpack (something in brackets) result;]");
         assert.isTrue(resultFileIsAttached, "result file should be attached");
 
         const resultFilenameConverted = testRunner.stdOutContained("webpack (something in brackets).webpack.result.md");

--- a/tasks/webpack-build-task/tests/shouldReplaceBracketsToParenthesisInTaskName.ts
+++ b/tasks/webpack-build-task/tests/shouldReplaceBracketsToParenthesisInTaskName.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 const mockRunnerDefinitions = "mockRunnerDefinitions";
 
 export const executeTest = (done: MochaDone) => {
-        const testPath = path.join(__dirname, mockRunnerDefinitions, "shouldReplaceBracketsToParenthesisInFilename.js");
+        const testPath = path.join(__dirname, mockRunnerDefinitions, "shouldReplaceBracketsToParenthesisInTaskName.js");
         const testRunner = new MockTestRunner(testPath);
         testRunner.run();
 

--- a/tasks/webpack-build-task/tests/suite.ts
+++ b/tasks/webpack-build-task/tests/suite.ts
@@ -95,7 +95,7 @@ describe("webpack build task", () => {
         shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning.executeTest);
 
     it(
-        "should replace brackets to parenthesis in filename",
+        "should replace brackets to parenthesis in task name",
         shouldReplaceBracketsToParenthesisInFilename.executeTest
     );
 

--- a/tasks/webpack-build-task/tests/suite.ts
+++ b/tasks/webpack-build-task/tests/suite.ts
@@ -11,7 +11,7 @@ import * as shouldGenerateMarkdownFileInCaseOfASuccessfulRun from "./shouldGener
 import * as shouldLogInformationAboutTheProcess from "./shouldLogInformationAboutTheProcess";
 import * as shouldPartiallySucceedIfNoErrorsButAtLeastOneWarning from "./shouldPartiallySucceedIfNoErrorsButAtLeastOneWarning";
 import * as shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning from "./shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning";
-import * as shouldReplaceBracketsToParenthesisInFilename from "./shouldReplaceBracketsToParenthesisInFilename";
+import * as shouldReplaceBracketsToParenthesisInTaskName from "./shouldReplaceBracketsToParenthesisInTaskName";
 import * as shouldReportErrorDetailInCaseOfWebpackBuildFailure from "./shouldReportErrorDetailInCaseOfWebpackBuildFailure";
 import * as shouldSucceedIfNoDisplayNameDefined from "./shouldSucceedIfNoDisplayNameDefined";
 import * as shouldSucceedIfNoErrorsAndWarnings from "./shouldSucceedIfNoErrorsAndWarnings";
@@ -96,7 +96,7 @@ describe("webpack build task", () => {
 
     it(
         "should replace brackets to parenthesis in task name",
-        shouldReplaceBracketsToParenthesisInFilename.executeTest
+        shouldReplaceBracketsToParenthesisInTaskName.executeTest
     );
 
     it(

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "webpack-vsts-extension",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "name": "webpack",
     "description": "bundle your assets, scripts, images, styles",
     "publisher": "Dealogic",


### PR DESCRIPTION
It's not enough to replace the `[]` in the result filename. `[]` have to be replaced in the title of the summary section too.

Still an improvement for #54 Webpack summary file error.
