### PR TITLE
Bug/overflow

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -102,7 +102,10 @@ ts-node options location | false | | Location of the ts-node options. If you lea
 
 ## <a id="release-notes"></a>Release Notes
 
-* 3.2.1 (22(09/2017)
+* 3.2.2 (03/10/2017)
+    * Avoid webpack task summary section overflow with adding scrollbar.
+    * Webpack task summary section uses same font as other sections.
+* 3.2.1 (22/09/2017)
     * Replacing `[]` brackets to `()` parenthesis in the title of the result summary section.
 * 3.2.0 (22/09/2017)
     * Support `[]` brackets in the display name of the task.

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,2 @@
-next-version: 3.2.1
+next-version: 3.2.2
 assembly-informational-format: '{SemVer}'

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ ts-node options location | false | | Location of the ts-node options. If you lea
 
 ## <a id="release-notes"></a>Release Notes
 
-* 3.2.1 (22(09/2017)
+* 3.2.2 (03/10/2017)
+    * Avoid webpack task summary section overflow with adding scrollbar.
+    * Webpack task summary section uses same font as other sections.
+* 3.2.1 (22/09/2017)
     * Replacing `[]` brackets to `()` parenthesis in the title of the result summary section.
 * 3.2.0 (22/09/2017)
     * Support `[]` brackets in the display name of the task.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wepback-vsts-extension",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wepback-vsts-extension",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "webpack Visual Studio Team System (VSTS) Extension",
   "main": "index.js",
   "scripts": {

--- a/tasks/webpack-build-task/package-lock.json
+++ b/tasks/webpack-build-task/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-build-task",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tasks/webpack-build-task/package.json
+++ b/tasks/webpack-build-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-build-task",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Webpack build task for Visual Studio Team System (VSTS)",
   "main": "index.js",
   "scripts": {},

--- a/tasks/webpack-build-task/summarySectionBuilder/index.ts
+++ b/tasks/webpack-build-task/summarySectionBuilder/index.ts
@@ -20,7 +20,7 @@ const createWebpackResultMarkdownFile = (
     const fixedTaskDisplayName = taskDisplayName.replace(/\[/g, "(").replace(/\]/g, ")").trim();
 
     const webpackResultFilename = generateWebpackResultFilename(workingFolder, fixedTaskDisplayName);
-    const resultFileContent = `<pre>${result.toString(webpackConfiguration)}</pre>`;
+    const resultFileContent = `<div class="copy-content-textarea"><pre style="font: inherit">${result.toString(webpackConfiguration)}</pre></div>`;
 
     tl.writeFile(webpackResultFilename, resultFileContent);
 

--- a/tasks/webpack-build-task/task.json
+++ b/tasks/webpack-build-task/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 3,
         "Minor": 2,
-        "Patch": 1
+        "Patch": 2
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/tasks/webpack-build-task/tests/shouldCompileSimpleWebpackProject.ts
+++ b/tasks/webpack-build-task/tests/shouldCompileSimpleWebpackProject.ts
@@ -14,7 +14,8 @@ export function executeTest(done: MochaDone): void {
 
         testRunner.run();
 
-        const content = fs.readFileSync("../../samples/multiple-webpack-build-steps/webpack-project-one/webpack test.webpack.result.md", "utf8");
+        let content = fs.readFileSync("../../samples/multiple-webpack-build-steps/webpack-project-one/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
 
         assert.isTrue(testRunner.succeeded, "webpack task should be succeeded");
 
@@ -22,7 +23,7 @@ export function executeTest(done: MochaDone): void {
         assert.include(content, "Version: webpack 1.14.0", "Expected webpack version is not found in the markdown file.");
         assert.include(content, "main.bundle.js  1.44 kB       0  [emitted]  main", "Expected bundle.js row is not found in the markdown file.");
 
-        assert.include(testRunner.stdout, content.replace("<pre>", "").replace("</pre>", ""), "The markdown file output has to be included in the standard out.");
+        assert.include(testRunner.stdout, content, "The markdown file output has to be included in the standard out.");
 
         done();
 }

--- a/tasks/webpack-build-task/tests/shouldCompileSimpleWebpackProjectWithIssues.ts
+++ b/tasks/webpack-build-task/tests/shouldCompileSimpleWebpackProjectWithIssues.ts
@@ -14,7 +14,8 @@ export function executeTest(done: MochaDone): void {
 
         testRunner.run();
 
-        const content = fs.readFileSync("../../samples/multiple-webpack-build-steps/webpack-project-two/webpack test.webpack.result.md", "utf8");
+        let content = fs.readFileSync("../../samples/multiple-webpack-build-steps/webpack-project-two/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
 
         assert.isFalse(testRunner.succeeded, "webpack task should not be succeeded");
         assert.isTrue(testRunner.failed, "webpack task should be failed");
@@ -25,7 +26,7 @@ export function executeTest(done: MochaDone): void {
         assert.include(content, "Version: webpack 1.14.0", "Expected webpack version is not found in the markdown file.");
         assert.include(content, "main.bundle.js  1.65 kB       0  [emitted]  main", "Expected bundle.js row is not found in the markdown file.");
 
-        assert.include(testRunner.stdout, content.replace("<pre>", "").replace("</pre>", ""), "The markdown file output has to be included in the standard out.");
+        assert.include(testRunner.stdout, content, "The markdown file output has to be included in the standard out.");
 
         done();
 }

--- a/tasks/webpack-build-task/tests/shouldCompileWebpack2Project.ts
+++ b/tasks/webpack-build-task/tests/shouldCompileWebpack2Project.ts
@@ -14,7 +14,8 @@ export function executeTest(done: MochaDone): void {
 
         testRunner.run();
 
-        const content = fs.readFileSync("../../samples/webpack-2/webpack test.webpack.result.md", "utf8");
+        let content = fs.readFileSync("../../samples/webpack-2/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
 
         assert.isTrue(testRunner.succeeded, "webpack task should be succeeded");
 
@@ -22,7 +23,7 @@ export function executeTest(done: MochaDone): void {
         assert.include(content, "Version: webpack 2.2.0", "Expected webpack version is not found in the markdown file.");
         assert.include(content, "bundle.js  544 kB       0  [emitted]  [big]  main", "Expected bundle.js row is not found in the markdown file.");
 
-        assert.include(testRunner.stdout, content.replace("<pre>", "").replace("</pre>", ""), "The markdown file output has to be included in the standard out.");
+        assert.include(testRunner.stdout, content, "The markdown file output has to be included in the standard out.");
 
         done();
 }

--- a/tasks/webpack-build-task/tests/shouldCompileWebpack3Project.ts
+++ b/tasks/webpack-build-task/tests/shouldCompileWebpack3Project.ts
@@ -14,7 +14,8 @@ export function executeTest(done: MochaDone): void {
 
         testRunner.run();
 
-        const content = fs.readFileSync("../../samples/webpack-3/webpack test.webpack.result.md", "utf8");
+        let content = fs.readFileSync("../../samples/webpack-3/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
 
         assert.isTrue(testRunner.succeeded, "webpack task should be succeeded");
 
@@ -22,7 +23,7 @@ export function executeTest(done: MochaDone): void {
         assert.include(content, "Version: webpack 3.0.0", "Expected webpack version is not found in the markdown file.");
         assert.include(content, "bundle.js  2.5 kB       0  [emitted]  main", "Expected bundle.js row is not found in the markdown file.");
 
-        assert.include(testRunner.stdout, content.replace("<pre>", "").replace("</pre>", ""), "The markdown file output has to be included in the standard out.");
+        assert.include(testRunner.stdout, content, "The markdown file output has to be included in the standard out.");
 
         done();
 }

--- a/tasks/webpack-build-task/tests/shouldCompileWebpack3ProjectWithIssues.ts
+++ b/tasks/webpack-build-task/tests/shouldCompileWebpack3ProjectWithIssues.ts
@@ -14,7 +14,8 @@ export function executeTest(done: MochaDone): void {
 
         testRunner.run();
 
-        const content = fs.readFileSync("../../samples/webpack-3-with-issues/webpack test.webpack.result.md", "utf8");
+        let content = fs.readFileSync("../../samples/webpack-3-with-issues/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
 
         assert.isFalse(testRunner.succeeded, "webpack task should not be succeeded");
         assert.isTrue(testRunner.failed, "webpack task should be failed");
@@ -26,7 +27,7 @@ export function executeTest(done: MochaDone): void {
         assert.include(content, "Version: webpack 3.0.0", "Expected webpack version is not found in the markdown file.");
         assert.include(content, "bundle.js  2.53 kB       0  [emitted]  main", "Expected bundle.js row is not found in the markdown file.");
 
-        assert.include(testRunner.stdout, content.replace("<pre>", "").replace("</pre>", ""), "The markdown file output has to be included in the standard out.");
+        assert.include(testRunner.stdout, content, "The markdown file output has to be included in the standard out.");
 
         done();
 }

--- a/tasks/webpack-build-task/tests/shouldCompileWebpackTypeScriptConfigProject.ts
+++ b/tasks/webpack-build-task/tests/shouldCompileWebpackTypeScriptConfigProject.ts
@@ -14,7 +14,8 @@ export function executeTest(done: MochaDone): void {
 
         testRunner.run();
 
-        const content = fs.readFileSync("../../samples/webpack-ts-config/webpack test.webpack.result.md", "utf8");
+        let content = fs.readFileSync("../../samples/webpack-ts-config/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
 
         assert.isTrue(testRunner.succeeded, "webpack task should be succeeded");
         assert.isFalse(testRunner.failed, "webpack task should not be failed");
@@ -23,7 +24,7 @@ export function executeTest(done: MochaDone): void {
         assert.include(content, "Version: webpack 3.5.5", "Expected webpack version is not found in the markdown file.");
         assert.include(content, "bundle.js  2.5 kB       0  [emitted]  main", "Expected bundle.js row is not found in the markdown file.");
 
-        assert.include(testRunner.stdout, content.replace("<pre>", "").replace("</pre>", ""), "The markdown file output has to be included in the standard out.");
+        assert.include(testRunner.stdout, content, "The markdown file output has to be included in the standard out.");
 
         done();
 }

--- a/tasks/webpack-build-task/tests/shouldFailIfThereAreWarningsButTreatedAsErrors.ts
+++ b/tasks/webpack-build-task/tests/shouldFailIfThereAreWarningsButTreatedAsErrors.ts
@@ -19,8 +19,10 @@ export const executeTest = (done: MochaDone) => {
 
         assert.equal(testRunner.warningIssues.length, 0, "there should be no warnings");
 
-        const content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
-        const expectedContent = "<pre>shouldFailIfThereAreWarningsButTreatedAsErrorsResult</pre>";
+        let content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
+
+        const expectedContent = "shouldFailIfThereAreWarningsButTreatedAsErrorsResult";
 
         assert.equal(content, expectedContent, "summary section file should contain the errors and warnings");
 

--- a/tasks/webpack-build-task/tests/shouldGenerateMarkdownFileInCaseOfASuccessfulRun.ts
+++ b/tasks/webpack-build-task/tests/shouldGenerateMarkdownFileInCaseOfASuccessfulRun.ts
@@ -10,8 +10,10 @@ export const executeTest = (done: MochaDone) => {
         const testRunner = new MockTestRunner(testPath);
         testRunner.run();
 
-        const content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
-        const expectedContent = "<pre>shouldSucceedIfNoErrorsAndWarningsResult</pre>";
+        let content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
+
+        const expectedContent = "shouldSucceedIfNoErrorsAndWarningsResult";
 
         assert.equal(content, expectedContent, "summary section file should be generated");
 

--- a/tasks/webpack-build-task/tests/shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning.ts
+++ b/tasks/webpack-build-task/tests/shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarning.ts
@@ -22,8 +22,10 @@ export const executeTest = (done: MochaDone) => {
         assert.equal(testRunner.warningIssues[0], "webpack test partially succeeded");
         assert.equal(testRunner.warningIssues[1], "webpack test: error");
 
-        const content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
-        const expectedContent = "<pre>shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarningResult</pre>";
+        let content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
+
+        const expectedContent = "shouldPartiallySucceedIfThereAreErrorsButTreatedAsWarningResult";
 
         assert.equal(content, expectedContent, "summary section file should contain the errors and warnings");
 

--- a/tasks/webpack-build-task/tests/shouldSucceedIfThereAreErrorsButTreatedAsInfo.ts
+++ b/tasks/webpack-build-task/tests/shouldSucceedIfThereAreErrorsButTreatedAsInfo.ts
@@ -14,8 +14,10 @@ export const executeTest = (done: MochaDone) => {
         assert.equal(testRunner.errorIssues.length, 0, "there should be no errors");
         assert.equal(testRunner.warningIssues.length, 0, "there should be no warnings");
 
-        const content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
-        const expectedContent = "<pre>shouldSucceedIfThereAreErrorsButTreatedAsInfoResult</pre>";
+        let content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
+
+        const expectedContent = "shouldSucceedIfThereAreErrorsButTreatedAsInfoResult";
 
         assert.equal(content, expectedContent, "summary section file should contain the errors and warnings");
 

--- a/tasks/webpack-build-task/tests/shouldSucceedIfThereAreWarningsButTreatedAsInfo.ts
+++ b/tasks/webpack-build-task/tests/shouldSucceedIfThereAreWarningsButTreatedAsInfo.ts
@@ -14,8 +14,10 @@ export const executeTest = (done: MochaDone) => {
         assert.equal(testRunner.errorIssues.length, 0, "there should be no errors");
         assert.equal(testRunner.warningIssues.length, 0, "there should be no warnings");
 
-        const content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
-        const expectedContent = "<pre>shouldSucceedIfThereAreWarningsButTreatedAsInfoResult</pre>";
+        let content = fs.readFileSync("tests/webpack test.webpack.result.md", "utf8");
+        content = content.replace("<div class=\"copy-content-textarea\"><pre style=\"font: inherit\">", "").replace("</pre></div>", "");
+
+        const expectedContent = "shouldSucceedIfThereAreWarningsButTreatedAsInfoResult";
 
         assert.equal(content, expectedContent, "summary section file should contain the errors and warnings");
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "webpack-vsts-extension",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "name": "webpack",
     "description": "bundle your assets, scripts, images, styles",
     "publisher": "Dealogic",


### PR DESCRIPTION
Fixing issue "#59 styling in the build summary is incorrect" with replacing `<pre>...</pre>` to `<div class="copy-content-textarea"><pre style="font: inherit">...</pre></div>`. With these scrollbar is added to avoid overflow of the summary section and font is inherited from parent element.